### PR TITLE
Update command namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,3 +112,7 @@ public function __invoke(Request $request)
 - Added initial tests for ServiceMakeCommand.
 - Added ability to pass multiple parameters when calling a service.
 - Update README.
+
+## 0.8.2 - 2018-07-26
+
+- With the new bright-components/adr package, we're changing the command namespace from 'bright' to 'adr'.

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Once the package is installed and the config is copied (optionally), you can beg
 From inside your project directory, in your terminal, run:
 
 ```bash
-php artisan bright:service StoreNewTask
+php artisan adr:service StoreNewTask
 ```
 
 Based on the configuration options above, this will create an 'App\Services\StoreNewTaskService' class.

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "bright-components/services",
     "description": "Service Implementation for Laravel Projects",
-    "version": "0.8.1",
+    "version": "0.8.2",
     "keywords": [
         "bright-components",
         "servicehandler"

--- a/src/Commands/ServiceMakeCommand.php
+++ b/src/Commands/ServiceMakeCommand.php
@@ -13,7 +13,7 @@ class ServiceMakeCommand extends GeneratorCommand
      *
      * @var string
      */
-    protected $signature = 'bright:service {name}';
+    protected $signature = 'adr:service {name}';
 
     /**
      * The console command description.

--- a/tests/Integration/ServiceCommandTest.php
+++ b/tests/Integration/ServiceCommandTest.php
@@ -11,7 +11,7 @@ class ServiceCommandTest extends IntegrationTestCase
     /** @test */
     public function bright_service_command_makes_service_with_correct_methods()
     {
-        Artisan::call('bright:service', ['name' => 'MyService']);
+        Artisan::call('adr:service', ['name' => 'MyService']);
 
         include_once base_path().'/app/Services/MyService.php';
 


### PR DESCRIPTION
- With the new bright-components/adr package, we're changing the command namespace from 'bright' to 'adr'.